### PR TITLE
New test machinery

### DIFF
--- a/opsdroid/core.py
+++ b/opsdroid/core.py
@@ -179,7 +179,7 @@ class OpsDroid:
             _LOGGER.error(_("Oops! Opsdroid is already running."))
 
     async def start(self):
-        """Run all created tasks concurrently."""
+        """Create tasks and then run all created tasks concurrently."""
         if len(self.skills) == 0:
             self.critical(_("No skills in configuration, at least 1 required"), 1)
 
@@ -191,6 +191,15 @@ class OpsDroid:
 
         self.create_task(self.parse(events.OpsdroidStarted()))
 
+        await self._run_tasks()
+
+    async def _run_tasks(self):
+        """
+        Run all created tasks concurrently.
+
+        This is separate from start() so that tests can run the loop without
+        creating any of the tasks.
+        """
         self._running = True
         with contextlib.suppress(asyncio.CancelledError):
             await asyncio.gather(*self.tasks)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for opsdroid."""

--- a/tests/mockmodules/__init__.py
+++ b/tests/mockmodules/__init__.py
@@ -1,0 +1,1 @@
+"""Test mocks for opsdroid."""


### PR DESCRIPTION
# Description

Here are a couple of fixes for new-test-machinery.
One commit fixes the lint.
The other commit fixes test_signals so that doesn't swallow errors anymore. But sadly the test suite is still dyeing with SIGHUP/SIGINT. Now, it is dyeing during this test instead of randomly later on (maybe after some timeout?)

pytest extension suspects:

- ~pytest-timeout~ uses SIGALRM, so that's not it.
- pytest-cov looks very likely ~but I haven't figured out how to get pycharm's breakpoints working in pytest plugins.~ https://github.com/pytest-dev/pytest-cov/blob/master/src/pytest_cov/embed.py#L115-L129 _ah breakpoints don't work because it's not running this code. the embed code is only used for subprocesses._

## Status
**UNDER DEVELOPMENT**

## Type of change

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

I'm running it in PyCharm w/ and w/o debugging to try and narrow the issues down.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
